### PR TITLE
Updated btce to new url as pointed out by @albabosh from #238.

### DIFF
--- a/src/exchanges/btce.cpp
+++ b/src/exchanges/btce.cpp
@@ -20,7 +20,7 @@ static json_t* adjustResponse(json_t *);
 
 static RestApi& queryHandle(Parameters &params)
 {
-  static RestApi query ("https://btc-e.com",
+  static RestApi query ("https://wex.nz",
                         params.cacert.c_str(), *params.logFile);
   return query;
 }


### PR DESCRIPTION
Still keeping it disabled by default though since trading on it is risky.